### PR TITLE
Fix startup and initialization

### DIFF
--- a/babele-register.js
+++ b/babele-register.js
@@ -98,6 +98,7 @@ Hooks.on("init", () => {
 			let root = game.modules.get(pack.metadata.packageName).flags.folder;
 			root.type = pack.metadata.type;
 			root._id = randomID();
+			root.flags = {source : this.data.module.id};
 
 			this.rootFolders[pack.metadata.id] = root._id;
 			const data = {name: root.name};
@@ -110,6 +111,7 @@ Hooks.on("init", () => {
 						f.folder = root._id;
 						f.name = pack.folders.contents.find(x => x._id == f._id).name;
 					}
+					f.flags.source = this.data.module.id;
 				}
 				return Folder.create(packFolders.concat(root), {keepId : true})
 			} else {
@@ -118,6 +120,7 @@ Hooks.on("init", () => {
 					if (!f.folder) {
 						f.folder = root._id;
 					}
+					f.flags.source = this.data.module.id;
 				}
 				return Folder.create(packFolders.concat(root), {keepId : true})
 			}

--- a/modules/initialization-archives1.js
+++ b/modules/initialization-archives1.js
@@ -7,38 +7,6 @@ Hooks.on("init", () => {
             default: false,
             type: Boolean
         });
-    
-        game.settings.registerMenu("wfrp4e-archives1", "init-dialog", {
-            name: "WFRP4e Zestaw Startowy",
-            label: "Konfiguracja",
-            hint: "Importuj lub aktualizuj zawartość modułu WFRP4e Archiwa Imperium vol I",
-            type: WFRP4eArchives1InitWrapper,
-            restricted: true
-        })
-
-        WFRP4eArchives1InitWrapper.prototype.render = function () {
-            let html = `<p class="notes">Zainicjalizować moduł zawartości WFRP4e Archiwa Imperium Vol I?<br><br>Zaimportuje lub zaktualizuje to wszystkich aktorów, przedmioty, dzienniki oraz sceny w twoim świecie, posortuje w folderach i umieści notatki na mapach</p>
-            <ul>
-                <li>13 Aktorów</li>
-                <li>58 Wpisów w dzienniku</li>
-                <li>35 Przedmiotów</li>
-                <li>2 Sceny</li>
-            </ul> <p class="notes">
-            Warhammer Fantasy Roleplay 4th Edition Archives of the Empire Vol. I Module.<br><br>
-
-            No part of this publication may be reproduced, distributed, stored in a retrieval system, or transmitted in any form by any means, electronic, mechanical, photocopying, recording or otherwise without the prior permission of the publishers.<br><br>
-            
-            Warhammer Fantasy Roleplay 4th Edition © Copyright Games Workshop Limited 2020. Warhammer Fantasy Roleplay 4th Edition, the Warhammer Fantasy Roleplay 4th Edition logo, GW, Games Workshop, Warhammer, The Game of Fantasy Battles, the twin-tailed comet logo, and all associated logos, illustrations, images, names, creatures, races, vehicles, locations, weapons, characters, and the distinctive likeness thereof, are either ® or TM, and/or © Games Workshop Limited, variably registered around the world, and used under licence. Cubicle 7 Entertainment and the Cubicle 7 Entertainment logo are trademarks of Cubicle 7 Entertainment Limited. All rights reserved.<br><br>
-            
-            <img src="modules/wfrp4e-archives1/c7.png" height=50 width=50/>   <img src="modules/wfrp4e-archives1/warhammer.png" height=50 width=50/>
-            <br>
-            Published by: <b>Cubicle 7 Entertainment Ltd</b><br>
-            Foundry Edition by <b>Russell Thurman (Moo Man)</b><br>
-            Special thanks to: <b>Games Workshop, Fatshark</b><br><br>
-            
-            <a href="mailto: info@cubicle7games.com">info@cubicle7games.com</a>`
-            new WarhammerModuleInitializer("wfrp4e-archives1", "WFRP4e Archives of the Empire Vol. I Initialization",html).render(true);
-        }
         
         setTimeout(async () => {
             

--- a/modules/initialization-starter-set.js
+++ b/modules/initialization-starter-set.js
@@ -8,39 +8,5 @@ Hooks.on("init", () => {
             default: false,
             type: Boolean
         });
-    
-        game.settings.registerMenu("wfrp4e-starter-set", "init-dialog", {
-            name: "WFRP4e Zestaw Startowy",
-            label: "Konfiguracja",
-            hint: "Importuj lub aktualizuj zawartość modułu WFRP4e Zestaw Startowy",
-            type: WFRP4eSSInitWrapper,
-            restricted: true
-        })
-
-        WFRP4eSSInitWrapper.prototype.render = function () {
-            let html = `<p class="notes">Zainicjalizować moduł zawartości WFRP4e Zestaw Startowy?<br><br>Zaimportuje lub zaktualizuje to wszystkich aktorów, przedmioty, dzienniki oraz sceny w twoim świecie, posortuje w folderach i umieści notatki na mapach</p>
-            <ul>
-            <li>60 Aktorów</li>
-            <li>8 Wpisów do dzienników (łącznie 122 strony)</li>
-            <li>3 Sceny - w tym mapa Ubersreik z pinezkami</li>
-            <li>4 Tablele - Rany Krytyczne</li>
-            </ul> <p class="notes">
-            Warhammer Fantasy Roleplay 4th Edition Starter Set Module.<br><br>
-
-            No part of this publication may be reproduced, distributed, stored in a retrieval system, or transmitted in any form by any means, electronic, mechanical, photocopying, recording or otherwise without the prior permission of the publishers.<br><br>
-            
-            Warhammer Fantasy Roleplay 4th Edition © Copyright Games Workshop Limited 2023. Warhammer Fantasy Roleplay 4th Edition, the Warhammer Fantasy Roleplay 4th Edition logo, GW, Games Workshop, Warhammer, The Game of Fantasy Battles, the twin-tailed comet logo, and all associated logos, illustrations, images, names, creatures, races, vehicles, locations, weapons, characters, and the distinctive likeness thereof, are either ® or TM, and/or © Games Workshop Limited, variably registered around the world, and used under licence. Cubicle 7 Entertainment and the Cubicle 7 Entertainment logo are trademarks of Cubicle 7 Entertainment Limited. All rights reserved.<br><br>
-            
-            <img src="modules/wfrp4e-starter-set/c7.png" height=50 width=50/>   <img src="modules/wfrp4e-starter-set/warhammer.png" height=50 width=50/>
-            <br>
-            Published by: <b>Cubicle 7 Entertainment Ltd</b><br>
-            Foundry Edition by <b>Russell Thurman (Moo Man)</b><br>
-            Special thanks to: <b>Games Workshop, Fatshark</b><br><br>
-            
-            <a href="mailto: info@cubicle7games.com">info@cubicle7games.com</a>
-            `
-
-            new WarhammerModuleInitializer("wfrp4e-starter-set", "WFRP4e - Inicjalizacja Zestawu Startowego",html).render(true);
-        }
     }
 })

--- a/modules/initialization-up-in-arms.js
+++ b/modules/initialization-up-in-arms.js
@@ -9,38 +9,6 @@ Hooks.on("init", () => {
             type: Boolean,
         });
 
-        game.settings.registerMenu("wfrp4e-up-in-arms", "init-dialog", {
-            name: "WFRP4e Pod Bronią - Konfiguracja",
-            label: "Konfiguracja",
-            hint: "Importuj lub aktualizuj zawartość modułu WFRP4e Pod Bronią",
-            type: WFRP4eUpInArmsInitWrapper,
-            restricted: true
-        });
-
-        WFRP4eUpInArmsInitWrapper.prototype.render = function () {
-            const html = `<p class="notes">Zainicjalizować moduł zawartości WFRP4e Pod Bronią?<br><br>Zaimportuje lub zaktualizuje to wszystkich aktorów, przedmioty, dzienniki oraz sceny w twoim świecie, posortuje w folderach i umieści notatki na mapach</p>
-            <ul>
-            <li>12 wpisy do dzienników (66 stron)</li>
-            <li>14 Tabel</li>
-            </ul> <p class="notes">
-            Warhammer Fantasy Roleplay 4th Edition Up in Arms Module.<br><br>
-
-            No part of this publication may be reproduced, distributed, stored in a retrieval system, or transmitted in any form by any means, electronic, mechanical, photocopying, recording or otherwise without the prior permission of the publishers.<br><br>
-            
-            Warhammer Fantasy Roleplay 4th Edition © Copyright Games Workshop Limited 2023. Warhammer Fantasy Roleplay 4th Edition, the Warhammer Fantasy Roleplay 4th Edition logo, GW, Games Workshop, Warhammer, The Game of Fantasy Battles, the twin-tailed comet logo, and all associated logos, illustrations, images, names, creatures, races, vehicles, locations, weapons, characters, and the distinctive likeness thereof, are either ® or TM, and/or © Games Workshop Limited, variably registered around the world, and used under licence. Cubicle 7 Entertainment and the Cubicle 7 Entertainment logo are trademarks of Cubicle 7 Entertainment Limited. All rights reserved.<br><br>
-            
-            <img src="modules/wfrp4e-up-in-arms/c7.png" height=50 width=50/>   <img src="modules/wfrp4e-up-in-arms/warhammer.png" height=50 width=50/>
-            <br>
-            Published by: <b>Cubicle 7 Entertainment Ltd</b><br>
-            Foundry Edition by <b>Russell Thurman (Moo Man)</b><br>
-            Special thanks to: <b>Games Workshop, Fatshark</b><br><br>
-            
-            <a href="mailto: info@cubicle7games.com">info@cubicle7games.com</a>`;
-            
-            new WarhammerModuleInitializer("wfrp4e-up-in-arms", "WFRP4e - Inicjalizacja Pod Bronią", html).render(true);
-        }
-    
-
         setTimeout(async () => {
             
             const batter = game.wfrp4e.config.groupAdvantageActions.find(a => a.name == "Batter");


### PR DESCRIPTION
W nowej wersji WarhammerLibrary dedykowanej Foundry v13 został ujednolicony sposób inicjalizowania modułów Warhammerowych. Całość opiera się teraz na jednej klasie renderującej dialog z komunikatem o zawartości modułu i guzikami do potwierdzenia inicjalizacji.

- ogarnąłem kod na tyle by nie sypał błędami w konsoli,
- ogarnąłem to nowe okienko z inicjalizacją by wyświetlała polskie teksty,
- wywaliłem niepotrzebny już kod spolszczający okienka z poprzedniej wersji (a przynajmniej tyle ile byłem pewien że mogę usunąć)
- przeklikałem się pobieżnie i wszystko wygląda ok

Po tych zmianach (i zmianach CSSowych z poprzedniego PR) spolszczenie się odpala normalnie i nie sypie błędami, ale wymagane są dalsze prace ponieważ WarhammerLibrary ma nowe wpisy z tekstami w swoim pliku `en.json` (między innymi dotyczące tych nowych okienek inicjalizacji) @Livithor  @BlazejGsh 

Co do kompatybilności wstecznej dałoby się to ogarnąć przy pomocy kilku niezbyt ładnych IFów (a pytanie co nas jeszcze czeka po analizie zmian w nowej wersji WWFRP i WHLib) - na razie odpuściłem temat, ale jest on do rozważenia (w takiej sytuacji trzeba by było przywrócić usunięty przeze mnie kod i jakoś go zaifować na wersję Foundry).

Dalsze TODO po zmergowaniu zmian:
1. uzupełnić brakujące tłumaczenia po aktualizacji WFRP i WHLib
2. przejrzeć czy jeszcze jest jakiś stary kod do wywalenia po ww. aktualizacjach
3. możliwe że WHLib wprowadził dodatkowe rzeczy wymagające spolszczenia poza standardowym JSONem z tekstami (zauważyłem że te niebieskie popupy dotyczące inicjalizacji mają zahardcodowane teksty po angielsku)
4. upewnić się że jeszcze gdzieś coś głęboko schowane nie sypie błędami